### PR TITLE
use tfvars file to set variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,5 @@ terraform/terraform.tfstate
 terraform/terraform.tfstate.backup
 terraform/.terraform.lock.hcl
 inventory/my-cluster
-terraform/vars.tf
 terraform/.terraform
 TODO.md

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,7 +1,7 @@
 [defaults]
 nocows = True
 roles_path = ./roles
-inventory  = ./hosts.ini
+inventory  = ./inventory/my-cluster/hosts.ini
 
 remote_tmp = $HOME/.ansible/tmp
 local_tmp  = $HOME/.ansible/tmp
@@ -10,3 +10,5 @@ become = True
 host_key_checking = False
 deprecation_warnings = False
 callback_whitelist = profile_tasks
+callback_enabled = yes
+display_failed_stderr = yes

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,20 +1,31 @@
-variable "username" {
-  description = "The username for the DB master user"
+variable "pm_user" {
+  description = "The username for the proxmox user"
   type        = string
   sensitive = false
-  default = ""
+  default = "root@pam"
 
 }
-variable "password" {
-  description = "The password for the DB master user"
+variable "pm_password" {
+  description = "The password for the proxmox user"
   type        = string
   sensitive = true
-  default = ""
 }
 
-variable "proxmox-host" {
-  description = "The username for the DB master user"
+variable "pm_tls_insecure" {
+  description = "Set to true to ignore certificate errors"
+  type = bool
+  default = false
+}
+
+variable "pm_host" {
+  description = "The hostname or IP of the proxmox server"
   type        = string
+}
+
+variable "pm_node_name" {
+  description = "name of the proxmox node to create the VMs on"
+  type = string
+  default = "pve"
 }
 
 variable "pvt_key" {}
@@ -36,3 +47,19 @@ variable "num_k3s_nodes_mem" {
 }
 
 variable "tamplate_vm_name" {}
+
+variable "master_ips" {
+  description = "List of ip addresses for master nodes"
+}
+
+variable "worker_ips" {
+  description = "List of ip addresses for worker nodes"
+}
+
+variable "networkrange" {
+  default = 24
+}
+
+variable "gateway" {
+  default = "192.168.3.1"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -3,7 +3,7 @@ variable "username" {
   type        = string
   sensitive = false
   default = ""
-  
+
 }
 variable "password" {
   description = "The password for the DB master user"
@@ -15,16 +15,12 @@ variable "password" {
 variable "proxmox-host" {
   description = "The username for the DB master user"
   type        = string
-  default = "192.168.3.110"
-  
 }
 
-variable "pvt_key" {
-  default = "~/.ssh/proxk3s"
-}
+variable "pvt_key" {}
 
 variable "num_k3s_masters" {
- default = 1 
+ default = 1
 }
 
 variable "num_k3s_masters_mem" {
@@ -39,6 +35,4 @@ variable "num_k3s_nodes_mem" {
  default = "4096"
 }
 
-variable "tamplate_vm_name" {
- default = "ubuntu-2004-cloudinit-template"
-}
+variable "tamplate_vm_name" {}

--- a/terraform/variables.tfvars.sample
+++ b/terraform/variables.tfvars.sample
@@ -1,0 +1,7 @@
+proxmox-host = "192.168.3.110"
+pvt_key = "~/.ssh/proxk3s"
+num_k3s_masters = 1
+#num_k3s_masters_mem = 4096
+num_k3s_nodes = 4
+#num_k3s_nodes_mem = 4096
+tamplate_vm_name = "ubuntu-2004-cloudinit-template"

--- a/terraform/variables.tfvars.sample
+++ b/terraform/variables.tfvars.sample
@@ -1,7 +1,17 @@
-proxmox-host = "192.168.3.110"
+pm_host = "192.168.3.110"
+pm_password = "password"
 pvt_key = "~/.ssh/proxk3s"
 num_k3s_masters = 1
 #num_k3s_masters_mem = 4096
 num_k3s_nodes = 4
 #num_k3s_nodes_mem = 4096
-tamplate_vm_name = "ubuntu-2004-cloudinit-template"
+tamplate_vm_name = "ubuntu-focal-cloudinit-template"
+master_ips = [
+  "192.168.3.81"
+]
+worker_ips = [
+  "192.168.3.91",
+  "192.168.3.92",
+  "192.168.3.93",
+  "192.168.3.94",
+]


### PR DESCRIPTION
The tf file defining the terraform variables should contain variable definitions and default values (which means the variable is optional to set). The variable values should be supplied via a tfvar file, separating functionality from values for specific environments.

I changed the variable definitions to reflect this and add a sample file "variables.tfvar.sample"