### PR TITLE
fix dns servers?

### DIFF
--- a/inventory/sample/group_vars/all.yml
+++ b/inventory/sample/group_vars/all.yml
@@ -11,4 +11,4 @@ metallb_version: "v0.12.1"
 metallb_range: "192.168.3.93-192.168.3.94"
 argocd: false
 argocd_service_type: LoadBalancer
-
+dns_servers: []

--- a/roles/prereq/defaults/main.yml
+++ b/roles/prereq/defaults/main.yml
@@ -1,0 +1,1 @@
+dns_servers: []

--- a/roles/prereq/tasks/main.yml
+++ b/roles/prereq/tasks/main.yml
@@ -18,6 +18,13 @@
     state: present
     reload: true
 
+- name: fix dns servers in resolv.conf
+  template:
+    src: resolv.conf.j2
+    dest: /etc/resolv.conf
+  when:
+    - dns_servers | length() > 0
+
 - name: Add br_netfilter to /etc/modules-load.d/
   copy:
     content: "br_netfilter"

--- a/roles/prereq/templates/resolv.conf.j2
+++ b/roles/prereq/templates/resolv.conf.j2
@@ -1,0 +1,3 @@
+{% for dns_server in dns_servers %}
+nameserver {{ dns_server }}
+{% endfor %}


### PR DESCRIPTION
I'm using ubuntu 20.04 and have the issue that for some reason, the DNS servers from cloud-init are not applied during vm launch. So I added a step to add dns server config to ansible.
This should have no impact if the dns_servers variable is not set.

If I find the cause of the cloud-init issue, this would be obsolete, for now, I'm leaving it here in case anyone else has this issue, too.