### PR TITLE
Replace template_file data call with templatefile() function

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -44,16 +44,12 @@ resource "proxmox_vm_qemu" "proxmox_vm_workers" {
 
 }
 
-data "template_file" "k8s" {
-  template = file("./templates/k8s.tpl")
-  vars = {
+resource "local_file" "k8s_file" {
+  content = templatefile("./templates/k8s.tpl", {
     k3s_master_ip = "${join("\n", [for instance in proxmox_vm_qemu.proxmox_vm_master : join("", [instance.default_ipv4_address, " ansible_ssh_private_key_file=", var.pvt_key])])}"
     k3s_node_ip   = "${join("\n", [for instance in proxmox_vm_qemu.proxmox_vm_workers : join("", [instance.default_ipv4_address, " ansible_ssh_private_key_file=", var.pvt_key])])}"
-  }
-}
+  })
 
-resource "local_file" "k8s_file" {
-  content  = data.template_file.k8s.rendered
   filename = "../inventory/my-cluster/hosts.ini"
 }
 


### PR DESCRIPTION
Hi there, great work on this!

Tried running it on my Apple Silicon M1 MacBook today and ran into an error – there is no `arm64` binary for the `hashicorp/template` provider. This replaces the `template_file` data call with the `templatefile()` function which has been available since Terraform v0.12, works just the same, and doesn't require an extra provider.